### PR TITLE
add go routines in IterCb

### DIFF
--- a/concurrent_map_bench_test.go
+++ b/concurrent_map_bench_test.go
@@ -196,3 +196,38 @@ func BenchmarkKeys(b *testing.B) {
 		m.Keys()
 	}
 }
+
+func BenchmarkConcurrentMapIterCb(b *testing.B) {
+
+	m := cmap.New()
+	for i:=0; i<1000000; i++ {
+		m.Set(strconv.Itoa(i), true)
+	}
+
+	b.ResetTimer()
+
+	for i:=0; i<b.N; i++ {
+		var count int64 =0
+		m.IterCb(func(key string, val interface{}) {
+			atomic.AddInt64(&count, 1)
+		})
+	}
+}
+
+
+func BenchmarkConcurrentMapIterConcurrentCb(b *testing.B) {
+
+	m := cmap.New()
+	for i:=0; i<1000000; i++ {
+		m.Set(strconv.Itoa(i), true)
+	}
+
+	b.ResetTimer()
+
+	for i:=0; i<b.N; i++ {
+		var count int64 =0
+		m.IterConcurrentCb(func(key string, val interface{}) {
+			atomic.AddInt64(&count, 1)
+		})
+	}
+}


### PR DESCRIPTION
according to https://github.com/orcaman/concurrent-map/issues/79
 create SHARD_COUNT go routines , one for each shard, and do some parrallelism